### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/linksys_velop/manifest.json
+++ b/custom_components/linksys_velop/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "linksys_velop",
   "name": "Linksys Velop",
+  "version": "0.1.1",
   "documentation": "https://www.home-assistant.io/components/linksys_velop",
   "requirements": [],
   "dependencies": [],


### PR DESCRIPTION
Updating the manifest.json file to fix warning referring to missing version key. This should prevent the add-on from refusing to load in Home Assistant V.2021.6.0